### PR TITLE
Add possibility to exclude posts from Instant Articles

### DIFF
--- a/build/inc/lhafb_ia.metaboxes.php
+++ b/build/inc/lhafb_ia.metaboxes.php
@@ -63,8 +63,13 @@ function afb_instant_articles($object, $box){
 	$afbia_o = (array) get_post_meta($object->ID, "_instant_article_options", true);
 
 	?>
+		<h4><?php _e("Exclude from Instant Articles", "afb"); ?></h4>
 		<p>
-			<h4><?php _e("Credits", "afb"); ?></h4>
+			<label><input type="checkbox" name="instant_article_options[exclude_post]" value="exclude" <?php echo isset($afbia_o['exclude_post']) ? ' checked' : ''; ?>> <?php _e("Don't send to facebook", "afb"); ?></label>
+		</p>
+
+		<h4><?php _e("Credits", "afb"); ?></h4>
+		<p>
 			<textarea name="instant_article_options[credits]" class="widefat"><?php echo isset($afbia_o['credits']) ? $afbia_o['credits'] : NULL; ?></textarea>
 		</p>
 

--- a/build/templates/feed-instant_articles.php
+++ b/build/templates/feed-instant_articles.php
@@ -77,8 +77,17 @@ do_action( 'rss_tag_pre', 'rss2' );
 		<description><![CDATA[<?php the_excerpt(); ?>]]></description>
 		<content:encoded><![CDATA[
         	<?php
-       			$the_template = LHAFB__PLUGIN_DIR . 'templates/instant_article.php';
-				load_template($the_template, false);
+			$template = 'instant_article.php';
+			$the_template = LHAFB__PLUGIN_DIR . 'templates/' . $template;
+			if ( $overridden_template = locate_template( $template ) ) {
+				// locate_template() returns path to file
+				// if either the child theme or the parent theme have overridden the template
+				load_template( $overridden_template, false );
+			} else {
+				// If neither the child nor parent theme have overridden the template,
+				// we load the template from the 'templates' sub-directory of the directory this file is in
+				load_template( $the_template, false );
+			}
 	        ?>
       	]]></content:encoded>
 	<?php

--- a/trunk/inc/lhafb_ia.core.php
+++ b/trunk/inc/lhafb_ia.core.php
@@ -81,6 +81,24 @@ class AFBInstantArticles {
 	 */
 	public function modify_query($query){
 		if ( !is_admin() && $query->is_main_query() && $query->is_feed('instant_articles')) {
+
+			// Exclude posts from query
+			// kinda dirty approach since the meta values are serialized
+			$meta_query = array(
+				'relation' => 'OR',
+				array(
+					'key' => '_instant_article_options',
+					'value' => 's:12:"exclude_post";s:7:"exclude";',
+					'compare' => 'NOT LIKE'
+				),
+				array(
+					'key' => '_instant_article_options',
+					'compare' => 'NOT EXISTS'
+				)
+			);
+			$query->set( 'meta_query', $meta_query );
+
+
 			// Set the number of posts to be shown on the feed
 			// If the number is not set or returns 0, fall back to the default posts_per_rss option.
 			$num = intval(get_option('afbia_articles_num'));

--- a/trunk/inc/lhafb_ia.metaboxes.php
+++ b/trunk/inc/lhafb_ia.metaboxes.php
@@ -63,8 +63,13 @@ function afb_instant_articles($object, $box){
 	$afbia_o = (array) get_post_meta($object->ID, "_instant_article_options", true);
 
 	?>
+		<h4><?php _e("Exclude from Instant Articles", "afb"); ?></h4>
 		<p>
-			<h4><?php _e("Credits", "afb"); ?></h4>
+			<label><input type="checkbox" name="instant_article_options[exclude_post]" value="exclude" <?php echo isset($afbia_o['exclude_post']) ? ' checked' : ''; ?>> <?php _e("Don't send to facebook", "afb"); ?></label>
+		</p>
+
+		<h4><?php _e("Credits", "afb"); ?></h4>
+		<p>
 			<textarea name="instant_article_options[credits]" class="widefat"><?php echo isset($afbia_o['credits']) ? $afbia_o['credits'] : NULL; ?></textarea>
 		</p>
 


### PR DESCRIPTION
This change adds a checkbox to the post meta box, which can be checked to exclude this post from Instant Articles feed. 

resolves #9 

Edit: 

Sorry for the merge conflict. I couldn't keep up with your changes. :-|
The next pull request will be done with a proper local dev environment according to the contribution rules.
