### PR TITLE
Order Post in Feed by modified date and not published date

### DIFF
--- a/build/inc/lhafb_ia.core.php
+++ b/build/inc/lhafb_ia.core.php
@@ -127,6 +127,7 @@ class AFBInstantArticles {
 			);
 			$query->set( 'meta_query', $meta_query );
 
+			$query->set( 'orderby', 'modified');
 
 			// Set the number of posts to be shown on the feed
 			// If the number is not set or returns 0, fall back to the default posts_per_rss option.

--- a/trunk/inc/lhafb_ia.core.php
+++ b/trunk/inc/lhafb_ia.core.php
@@ -127,6 +127,7 @@ class AFBInstantArticles {
 			);
 			$query->set( 'meta_query', $meta_query );
 
+			$query->set( 'orderby', 'modified');
 
 			// Set the number of posts to be shown on the feed
 			// If the number is not set or returns 0, fall back to the default posts_per_rss option.


### PR DESCRIPTION
I've been thinking about this for quite some time and I think ordering the feed by modified date would be better. Imagine an old post which gets updated and it is not included in the default 10 posts-limit of the feed. Then the Instant Article at Facebook will never be updated because Facebook doesn't see the changes and readers will only see the outdated post. Ordering the Feed by modified date would solve this issue.

This is from the [Facebook Dev Docs](https://developers.facebook.com/docs/instant-articles/publishing/setup-rss-feed):

> As a best practice, we recommend that your RSS feed includes only articles that have been created or **updated** in the last ten minutes to ensure a sufficient overlap between pulls of your RSS feed. 
