### PR TITLE
Hook to add elements to article body

### DIFF
--- a/build/templates/instant_article.php
+++ b/build/templates/instant_article.php
@@ -101,6 +101,8 @@ if(defined("DEV_IA")){
 		</figure>
 	<?php endif; ?>
 
+	<?php do_action( 'afbia_article_body', $post->ID); ?>
+
 	<footer>
 		<?php if(isset($options['credits']) && !empty($options['credits'])): ?>
 			<!-- Credits for your article -->

--- a/trunk/templates/instant_article.php
+++ b/trunk/templates/instant_article.php
@@ -101,6 +101,8 @@ if(defined("DEV_IA")){
 		</figure>
 	<?php endif; ?>
 
+	<?php do_action( 'afbia_article_body', $post->ID); ?>
+
 	<footer>
 		<?php if(isset($options['credits']) && !empty($options['credits'])): ?>
 			<!-- Credits for your article -->


### PR DESCRIPTION
Would help to fix #29 

Example Usage in a plugin/theme:

```
function your_body_function($id) {
    echo '
    <figure class="op-tracker">
        <iframe>
            <!-- Include full analytics code here -->
        </iframe>
    </figure>
    ';
}
add_action( 'afbia_article_body', 'your_body_function', 10, 1);
```
