### PR TITLE
Add Tracking Pixel For Jetpack Stats

### DIFF
--- a/build/afb_instant_articles.php
+++ b/build/afb_instant_articles.php
@@ -32,6 +32,7 @@ require_once LHAFB__PLUGIN_DIR . "inc/lhafb_ia.core.php"; // The actual core of 
 require_once LHAFB__PLUGIN_DIR . "inc/lhafb_ia.metaboxes.php"; // The metaboxes, that are loaded in the admin views
 require_once LHAFB__PLUGIN_DIR . "inc/lhafb_ia.settings.php"; // The settings options needed for the plugin
 require_once LHAFB__PLUGIN_DIR . "inc/lhafb_ia.filters.php"; // The filters needed to morph the code for instant articles
+require_once LHAFB__PLUGIN_DIR . "inc/lhafb_ia.jetpack-support.php"; // The filters needed to support the jetpack plugin
 require_once LHAFB__PLUGIN_DIR . "inc/embeds.php"; // The embeds filter
 
 // Initialize the main plugin class

--- a/build/inc/lhafb_ia.core.php
+++ b/build/inc/lhafb_ia.core.php
@@ -10,6 +10,7 @@ class AFBInstantArticles {
 		$this->action_dispatcher();
 
 		$this->content_filters = new AFBInstantArticles_Filters();
+		$this->jetpack_support = new AFBInstantArticles_JetpackSupport();
 	}
 
 

--- a/build/inc/lhafb_ia.jetpack-support.php
+++ b/build/inc/lhafb_ia.jetpack-support.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @package afb_ia
+ */
+
+class AFBInstantArticles_JetpackSupport {
+
+	/**
+	 * The class constructor.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function __construct(){
+		add_action( 'init', array($this, "init") );
+	}
+
+	function init() {
+		if(class_exists('Jetpack')){
+			if ( Jetpack::is_module_active( 'stats' ) OR true) {
+				add_action( 'afbia_article_body', array($this, 'add_jetpack_stats_pixel') );
+			}
+		}
+	}
+
+	/**
+	 * This function adds the tracking pixel to the feed.
+	 * Called by action 'afbia_article_body'
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function add_jetpack_stats_pixel() {
+		$pixelUrl = $this->build_jetpack_stats_pixel_url();
+		?>
+		<figure class="op-tracker">
+			<iframe>
+				<script>
+					var x = new Image();
+					x.src = "<?php echo esc_js($pixelUrl); ?>";
+				</script>
+			</iframe>
+		</figure>
+		<?php
+	}
+
+
+	/**
+	 * This function builds the tracking pixel url
+	 * Called by action 'afbia_article_body'
+	 * Credits: https://github.com/Automattic/amp-wp/blob/6879e7d98e804924b0567baa77d9d189890a991d/jetpack-helper.php#L51
+	 *
+	 * @access public
+	 * @return string The tracking pixel url
+	 */
+	function build_jetpack_stats_pixel_url() {
+		global $post;
+
+		$blog = Jetpack_Options::get_option( 'id' );
+		$tz = get_option( 'gmt_offset' );
+		$v = 'ext';
+		$blog_url = parse_url( site_url() );
+		$srv = $blog_url['host'];
+		$j = sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION );
+		$post = !empty($post) ? $post->ID : 0;
+		$data = compact( 'v', 'j', 'blog', 'post', 'tz', 'srv' );
+
+		$data['host'] = rawurlencode( $_SERVER['HTTP_HOST'] );
+		$data['rand'] = (float)rand()/(float)getrandmax();
+		$data['ref'] = '';
+		$data = array_map( 'rawurlencode' , $data );
+
+		return add_query_arg( $data, 'https://pixel.wp.com/g.gif' );
+	}
+
+
+}

--- a/build/inc/lhafb_ia.jetpack-support.php
+++ b/build/inc/lhafb_ia.jetpack-support.php
@@ -17,7 +17,7 @@ class AFBInstantArticles_JetpackSupport {
 
 	function init() {
 		if(class_exists('Jetpack')){
-			if ( Jetpack::is_module_active( 'stats' ) OR true) {
+			if ( Jetpack::is_module_active( 'stats' )) {
 				add_action( 'afbia_article_body', array($this, 'add_jetpack_stats_pixel') );
 			}
 		}


### PR DESCRIPTION
After seeing that both the "official" instant articles plugin as well as the AMP plugin of Automattic are using an image pixel to track page views for Jetpack Stats, I've tried to replicate it for this plugin:

see: https://github.com/Automattic/facebook-instant-articles-wp/blob/3db227afe5c2c9444fbf972dead28bb13be919e9/wpcom-helper.php#L30

and: https://github.com/Automattic/amp-wp/blob/6879e7d98e804924b0567baa77d9d189890a991d/jetpack-helper.php#L51 
